### PR TITLE
Adding custom code with two event handlers, for the Incident entity

### DIFF
--- a/srv/services.js
+++ b/srv/services.js
@@ -1,0 +1,30 @@
+const cds = require('@sap/cds')
+
+class ProcessorService extends cds.ApplicationService {
+  /** Registering custom event handlers */
+  init() {
+    this.before("UPDATE", "Incidents", (req) => this.onUpdate(req));
+    this.before("CREATE", "Incidents", (req) => this.changeUrgencyDueToSubject(req.data));
+
+    return super.init();
+  }
+
+  changeUrgencyDueToSubject(data) {
+    if (data) {
+      const incidents = Array.isArray(data) ? data : [data];
+      incidents.forEach((incident) => {
+        if (incident.title?.toLowerCase().includes("urgent")) {
+          incident.urgency = { code: "H", descr: "High" };
+        }
+      });
+    }
+  }
+
+  /** Custom Validation */
+  async onUpdate (req) {
+    const { status_code } = await SELECT.one(req.subject, i => i.status_code).where({ID: req.data.ID})
+    if (status_code === 'C')
+      return req.reject(`Can't modify a closed incident`)
+  }
+}
+module.exports = { ProcessorService }


### PR DESCRIPTION
In this code two event handlers have been added:

The first one will be triggered before updating the Incident entity and will check the status of the Incident, if it is already closed then the update will not take place and the message “Can't modify a closed incident” will be displayed

![image](https://github.com/user-attachments/assets/dc347ccd-77b7-4eef-b5dd-415adc208f66)

The second event handler will be triggered before creating a record in the Incident entity, it will check the title of the record being sent for the creation and look for a match with the word urgent (regardless of case) and if a match is found, the incident status will be updated to code: “H”, descr: “High”.

![image](https://github.com/user-attachments/assets/91dfce53-21e2-42cd-bca5-395bb15f2c04)

![image](https://github.com/user-attachments/assets/8d5b660d-c0fd-47cd-aec0-36e6c4b30a35)
