### PR TITLE
Adding a Launch Page for local testing

### DIFF
--- a/app/launchpage.html
+++ b/app/launchpage.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <script>
+            window['sap-ushell-config'] = {
+                defaultRenderer: 'fiori2',
+                services: {
+                    NavTargetResolution: {
+                        config: {
+                            allowTestUrlComponentConfig: true,
+                            enableClientSideTargetResolution: true
+                        }
+                    }           
+                },
+                applications: {
+                    "incidents-app": {
+                        title: 'Incident-Management',
+                        description: 'Incidents',
+                        additionalInformation: 'SAPUI5.Component=ns.incidents',
+                        applicationType: 'URL',
+                        url: "./incidents/webapp",
+                        navigationMode: 'embedded'
+                    }
+            }
+        }
+        </script>
+        <script src="https://ui5.sap.com/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
+        <script
+            src="https://ui5.sap.com/resources/sap-ui-core.js"
+            data-sap-ui-libs="sap.m, sap.ushell, sap.fe.templates"
+            data-sap-ui-compatVersion="edge"
+            data-sap-ui-theme="sap_horizon"
+            data-sap-ui-frameOptions="allow"
+            data-sap-ui-bindingSyntax="complex"
+        ></script>
+        <script>
+            sap.ui.getCore().attachInit(function() {
+                sap.ushell.Container.createRenderer().placeAt('content');
+            });
+        </script>
+    </head>
+    <body class="sapUiBody" id="content"></body>
+</html>


### PR DESCRIPTION
You have already generated the Incident Management application and can start it in the browser from SAP Business Application Studio. However, you can also add a launch page for local testing. This page looks like a real site, but is just a local copy of the otherwise centrally managed SAP Build Work Zone, standard edition site and comes with a limited version of its functionality. There’s no option to add or remove applications via configuration, user roles aren’t taken into account, and end-user personalization is also not included.

In the current implementation, you can open the Incident Management application via the app/incidents/webapp/index.html file and there is no launch page. If you now create a second application using the SAP Fiori application generator within your project, it will be generated in the same way, again with its own index.html file. Instead, you can use a launch page for all the applications. You can add a launch page by creating an HTML file that uses the built-in SAPUI5 shell in the app folder.

Create a new launchpage.html file in the app folder of the INCIDENT-MANAGEMENT application.

Result

![image](https://github.com/user-attachments/assets/a23f7117-2a90-48c8-b4ff-71f6aedc28cb)


