### PR TITLE
Defining CDS Restrictions and Roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,26 @@
   },
   "sapux": [
     "app/incidents"
-  ]
+  ],
+  "cds": {
+    "requires": {
+      "[development]": {
+        "auth": {
+          "kind": "mocked",
+          "users": {
+            "incident.support@tester.sap.com": {
+              "password": "initial",
+              "roles": ["support"]
+            },
+            "alice": {
+              "roles": ["support"]
+            },
+            "bob": {
+              "roles": ["support"]
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/srv/services.cds
+++ b/srv/services.cds
@@ -19,3 +19,6 @@ service AdminService {
 }
 
 annotate ProcessorService.Incidents with @odata.draft.enabled;
+annotate ProcessorService with @(requires: 'support');
+
+annotate AdminService with @(requires: 'admin');


### PR DESCRIPTION
 Add CAP role restrictions to entities:

To specify restrictions, add the annotate ProcessorService with @(requires: 'support'); and the annotate AdminService with @(requires: 'admin'); lines to the srv/services.cds file;

With these changes, users with the support role can view and change the incidents and customers, while users with the admin role can perfom admin activities such as auditing logs.

-------------------------------------------------------
Add users for local testing:

The authorization checks that you added to the CAP model apply not only when deployed in the cloud but also when testing locally. Therefore, you need a way to log in to the application locally.

CAP offers a possibility to add local users for testing as part of the cds configuration. In this tutorial, you use the development profile in package.json file to add the users.

--------------------------------------------------------
Result:

When accessing the Incidents service of the Incident Management application in your browser, you get a basic auth popup now, asking for your user and password. You can use the users to log in and see how it works.

![image](https://github.com/user-attachments/assets/5b889585-92b2-428a-a18c-1549193fe8b5)
